### PR TITLE
add unplugin-auto-import 插件,提供vue和uniapp的api自动引入能力

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+dist
+node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 dist
 node_modules
+auto-imports.d.ts

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@dcloudio/uni-mp-toutiao": "^3.0.0-alpha-3040120220308001",
     "@dcloudio/uni-mp-weixin": "^3.0.0-alpha-3040120220308001",
     "@dcloudio/uni-quickapp-webview": "^3.0.0-alpha-3040120220308001",
+    "unplugin-auto-import": "^0.6.6",
     "vue": "^3.2.31",
     "vue-i18n": "^9.1.9",
     "vuex": "^4.0.2"

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { onLaunch, onShow, onHide } from "@dcloudio/uni-app";
 onLaunch(() => {
   console.log("App Launch");
 });

--- a/src/pages/index/index.vue
+++ b/src/pages/index/index.vue
@@ -8,7 +8,6 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue'
 const title = ref('Hello')
 </script>
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,5 +12,11 @@
     "lib": ["esnext", "dom"],
     "types": ["@dcloudio/types"]
   },
-  "include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.tsx", "src/**/*.vue"]
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.d.ts",
+    "src/**/*.tsx",
+    "src/**/*.vue",
+    "./auto-imports.d.ts"
+  ]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,8 @@
 import { defineConfig } from "vite";
 import uni from "@dcloudio/vite-plugin-uni";
+import AutoImport from "unplugin-auto-import/vite";
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [uni()],
+  plugins: [uni(), AutoImport({ imports: ["vue", "uni-app"] })],
 });


### PR DESCRIPTION
我为unplugin-auto-import提交了uniapp preset的pr: 
- https://github.com/antfu/unplugin-auto-import/pull/119

before:
<img src="https://user-images.githubusercontent.com/26431026/158562490-ae1c902b-40ac-450b-9bda-e7f4c0bd705c.png" height="200px">
after:
<img src="https://user-images.githubusercontent.com/26431026/158562567-8fa1f339-de63-47ea-8000-56a412304ee3.png" height="200px">
<img src="https://user-images.githubusercontent.com/26431026/158563979-7ce22335-50e9-4bf9-9a89-99b44cc600bd.png" height="200px">

由于会在目录中构建dts声明文件,所以我还创建了.gitignore文件


