### PR TITLE
基于最新 vue 官方标准完善 tsconfig 相关配置

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,21 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+
+node_modules
+.DS_Store
+dist
+*.local
+
+# Editor directories and files
+.idea
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html>
   <head>
     <meta charset="UTF-8" />
     <script>

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "@dcloudio/uni-cli-shared": "3.0.0-alpha-3061420221216001",
     "@dcloudio/uni-stacktracey": "3.0.0-alpha-3061420221216001",
     "@dcloudio/vite-plugin-uni": "3.0.0-alpha-3061420221216001",
+    "@vue/tsconfig": "^0.1.3",
     "typescript": "^4.9.4",
     "vite": "4.0.3"
   }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "build:mp-weixin": "uni build -p mp-weixin",
     "build:quickapp-webview": "uni build -p quickapp-webview",
     "build:quickapp-webview-huawei": "uni build -p quickapp-webview-huawei",
-    "build:quickapp-webview-union": "uni build -p quickapp-webview-union"
+    "build:quickapp-webview-union": "uni build -p quickapp-webview-union",
+    "type-check": "vue-tsc --noEmit"
   },
   "dependencies": {
     "@dcloudio/uni-app": "3.0.0-alpha-3061420221216001",
@@ -59,6 +60,7 @@
     "@dcloudio/vite-plugin-uni": "3.0.0-alpha-3061420221216001",
     "@vue/tsconfig": "^0.1.3",
     "typescript": "^4.9.4",
-    "vite": "4.0.3"
+    "vite": "4.0.3",
+    "vue-tsc": "^1.0.24"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,10 @@
   "extends": "@vue/tsconfig/tsconfig.json",
   "compilerOptions": {
     "sourceMap": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    },
     "lib": ["esnext", "dom"],
     "types": ["@dcloudio/types"]
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,14 +1,7 @@
 {
+  "extends": "@vue/tsconfig/tsconfig.json",
   "compilerOptions": {
-    "target": "esnext",
-    "useDefineForClassFields": true,
-    "module": "esnext",
-    "moduleResolution": "node",
-    "strict": true,
-    "jsx": "preserve",
     "sourceMap": true,
-    "resolveJsonModule": true,
-    "esModuleInterop": true,
     "lib": ["esnext", "dom"],
     "types": ["@dcloudio/types"]
   },


### PR DESCRIPTION
该 PR 主要增加以下 typescript 相关功能：
1. 增加 `@vue/tsconfig` 做为默认 `tsconfig.json` 的配置，源于 **Vue** 官方的 [@vue/tsconfig](https://github.com/vuejs/tsconfig/blob/main/tsconfig.json#L3-L38)
2. 增加 `baseUrl` 和 `paths` 配置，源于 **create-vue** 官方的  [tsconfig.json](https://github.com/vuejs/create-vue/blob/main/template/tsconfig/base/tsconfig.json#L5-L8)
3. 增加 `vue-tsc` 命令行类型检查工具，源于 **volar** 官方的 [vue-tsc](https://github.com/johnsoncodehk/volar/tree/master/vue-language-tools/vue-tsc)

其他：
- 增加 `.gitignore` 忽略文件，基于 **create-vue** 官方的 [.gitignore](https://github.com/vuejs/create-vue/blob/main/template/base/_gitignore#L1-L12)
- 删除冗余 `lang="en"`，避免浏览器端出现翻译弹窗。

