### PR TITLE
fix: 与vite-plugin-uni中的vite版本冲突

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "@dcloudio/vite-plugin-uni": "3.0.0-alpha-3061620221230002",
     "@vue/tsconfig": "^0.1.3",
     "typescript": "^4.9.4",
-    "vite": "4.0.4",
     "vue-tsc": "^1.0.24"
   }
 }


### PR DESCRIPTION
因为依赖树中已经存在vite，这里似乎不需要再引入vite。